### PR TITLE
Disable notifications for irc.freenode.net#openra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,6 @@ branches:
    - /^prep-.*$/
    - bleed
  
-# Notify developers when build passed/failed.
-notifications:
-  irc:
-    template:
-      - "%{repository}#%{build_number} %{commit} %{author}: %{message} %{build_url}"
-    channels:
-      - "irc.freenode.net#openra"
-    use_notice: true
-    skip_join: true
-
 before_deploy:
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`


### PR DESCRIPTION
This will stop sending notifications to #OpenRA on FreeNode IRC. http://logs.openra.net/

We have no idea what you are doing: why Travis CI has been set up, why you are doing minor changes through the GitHub web interface and why you are sending those as pull requests. Please stop doing so.

You are however still invited to join the http://www.openra.net/community/ if you want to really work on some features.